### PR TITLE
docs: update CLAUDE.md with full codebase state; fix lint errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,28 +32,64 @@ Do not introduce:
 ## Architecture
 
 ```
-core/              → pure Python engines (no heavy IO)
-adapters/          → thin wrappers for all external IO
-Core_Scripts/      → experimental/auxiliary scripts (not imported by server.py)
-tests/             → pytest suite
-docs/              → API and architecture specs
-web/               → static frontend (served at /ui by server.py)
-Audio_Layers/      → static audio assets  → served at /media/audio
-Visual_Scenes/     → static image assets  → served at /media/visual
-learning_set/      → input ZIPs for FAISS knowledge base
-tools/             → one-off utility scripts (not part of the app)
+core/                  → pure Python engines (no heavy IO)
+adapters/              → thin wrappers for all external IO
+Core_Scripts/          → experimental/auxiliary scripts (not imported by server.py)
+tests/                 → pytest suite (25 files, 335+ tests)
+docs/                  → API and architecture specs
+web/                   → static frontend (served at /ui by server.py)
+Audio_Layers/          → static audio assets  → served at /media/audio
+Visual_Scenes/         → static image assets  → served at /media/visual
+learning_set/          → input ZIPs for FAISS knowledge base
+tools/                 → one-off utility scripts (not part of the app)
+emotion_fusion_engine/ → standalone multi-modal emotion analysis service
+templates/             → improved/refactored engine templates (not imported by server.py)
+Archived_Assets/       → archived legacy files
+Documentation/         → legacy documentation
 ```
 
-Entry points:
+### Entry Points
 
 | File | Engine | Interface |
 |---|---|---|
-| `server.py` | `core/namo_omega_engine.py` | REST API (port 8000) |
-| `memory_service.py` | standalone | REST API (port 8081) |
+| `server.py` | Engine registry (5 engines) | REST API (port 8000) |
+| `memory_service.py` | standalone `MemoryManager` | REST API (port 8081) |
 | `app.py` | `core/dark_system.py` | CLI |
 | `main.py` | `core/character_profile.py` | CLI |
+| `rinlada_fusion.py` | `RinladaAI` | also registered in engine registry |
+| `seraphina_ai_complete.py` | `SeraphinaAI` | also registered in engine registry |
 
-Rules:
+### Engine Registry (server.py)
+
+`server.py` uses a lazy-singleton `_EngineRegistry` — engines are registered at import time and instantiated on first request. The default engine (`omega`) is pre-loaded at startup.
+
+```
+omega      → NaMoOmegaEngine       (default, pre-loaded)
+dark       → DarkNaMoSystem
+rinlada    → RinladaAI
+seraphina  → SeraphinaAI
+ultimate   → NaMoUltimateBrain
+```
+
+Select engine per request via the `engine` field in the chat request body, or set `DEFAULT_ENGINE` env var.
+
+### API Endpoints
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/` | none | Status + available engines |
+| POST | `/chat` | none | Main chat (public) |
+| POST | `/v1/chat` | optional `X-API-Key` | Authenticated chat |
+| POST | `/v1/chat/stream` | optional `X-API-Key` | SSE streaming chat |
+| GET | `/v1/engines` | none | List registered engines |
+| GET | `/v1/health` | none | Health check |
+| GET | `/v1/status` | none | Status of all loaded engines |
+| GET | `/v1/admin/sessions` | `X-Admin-Secret` | Active sessions per engine |
+
+Do not rename or change any of these paths — they are production routes.
+
+### Architecture Rules
+
 - All external service calls (OpenAI, ElevenLabs, emotion API, memory JSON) go through `adapters/` only
 - `core/` engines must be testable without network or filesystem calls
 - New feature? Add engine logic to `core/`, IO to `adapters/`, wire them in the entry point
@@ -69,17 +105,60 @@ Rules:
 }
 ```
 
-### Cognitive Stack (core/)
+### Per-Session State Isolation
 
-Opt-in subsystems that make persona behaviour more human-like.
+All mutable state is keyed by `session_id` (falls back to `"default"`). `server.py` runs an async cleanup loop that evicts sessions older than `SESSION_TTL_SECONDS` (default 3600s). The following per-instance dicts are cleaned:
+
+| Engine | Attribute |
+|---|---|
+| `NaMoOmegaEngine` | `_session_states`, `session_history` |
+| `NaMoUltimateBrain` | `_session_arousal` |
+| `DarkNaMoSystem` | `_session_intensity` |
+| `RinladaAI` | `_session_arousal` |
+| `SeraphinaAI` | `_session_arousal` |
+
+### Rate Limiting
+
+`server.py` uses a sliding-window `_RateLimiter` keyed by client IP.
+Configured via `settings.rate_limit_calls` and `settings.rate_limit_period` (default 60 calls/60s).
+
+---
+
+## Core Modules (`core/`)
+
+### Base & Bundle
+
+| File | Class | Responsibility |
+|---|---|---|
+| `base_persona.py` | `BasePersonaEngine` (ABC) | Abstract base; defines `process_input()`, `get_status()`, `init_cognition()` |
+| `base_persona.py` | `CognitiveCore` | Bundle: wraps EmotionEngine + CognitiveStream + LearningEngine; call `cognitive.process()` once per turn |
+
+### Persona Engines
+
+| File | Class | Notes |
+|---|---|---|
+| `namo_omega_engine.py` | `NaMoOmegaEngine` | Primary engine. Contains `SinSystem`, `SensoryOverloadManager`, `PersonaOrchestrator`, `RelationshipEngine`. Reads env directly for LLM init — follow existing pattern when modifying. |
+| `dark_system.py` | `DarkNaMoSystem` | CLI engine. Metaphysical Phase 4.2. Safe word: **"อภัย"** triggers aftercare mode. |
+| `namo_ultimate_engine.py` | `NaMoUltimateBrain` | Advanced engine with `ForbiddenDialogueLibrary`, session arousal, multi-persona support. |
+| `character_profile.py` | `CharacterProfile` | CLI engine for `main.py`. Persists state to `namo_state.json`. |
+
+Engines registered in `server.py` but defined in root-level files:
+
+| File | Class | Notes |
+|---|---|---|
+| `rinlada_fusion.py` | `RinladaAI` | Rinlada character (Dark Muse / Forbidden Aunt). Optional TensorFlow/Transformers. |
+| `seraphina_ai_complete.py` | `SeraphinaAI` | Seraphina character (The Seductive Enigma). Deep psychological profiling. Optional TensorFlow/BERT. |
+
+### Cognitive Stack (opt-in)
+
 Activate by calling `self.init_cognition()` in an engine's `__init__`.
 
 | Module | Class | Responsibility |
 |---|---|---|
-| `core/emotion_engine.py` | `EmotionEngine` | 5-D continuous emotion (joy/arousal/trust/anger/desire) with momentum + baseline decay |
-| `core/cognitive_stream.py` | `CognitiveStream` | Internal monologue (impulse/reflection/memory/conflict/desire thoughts) injected into LLM prompt |
-| `core/learning_engine.py` | `LearningEngine` | Observes interactions, evolves 4 persona traits, persists to `learned_patterns.json` |
-| `core/base_persona.py` | `CognitiveCore` | Bundle: `emotion`, `thoughts`, `learning` — call `cognitive.process()` once per turn |
+| `core/emotion_engine.py` | `EmotionEngine` | 5-D continuous emotion (joy/arousal/trust/anger/desire) with momentum (INERTIA=0.65) + baseline decay (DECAY_RATE=0.06) |
+| `core/cognitive_stream.py` | `CognitiveStream` | Internal monologue queue (max 6 thoughts): impulse/reflection/memory/conflict/desire — injected into LLM prompt |
+| `core/learning_engine.py` | `LearningEngine` | Observes interactions, evolves 4 traits (boldness/playfulness/vulnerability/expressiveness), persists to `learned_patterns.json` |
+| `core/base_persona.py` | `CognitiveCore` | Bundle — call `cognitive.process()` once per turn |
 
 `CognitiveCore.process()` returns:
 ```python
@@ -92,9 +171,38 @@ Activate by calling `self.init_cognition()` in an engine's `__init__`.
 }
 ```
 
+### Supporting Modules
+
+| Module | Class | Responsibility |
+|---|---|---|
+| `core/intent_analyzer.py` | `IntentAnalyzer` | Lightweight intent extraction (no LLM) — anger/rejection/comfort/nostalgia/lust/command/affection/tease; Thai + English keywords |
+| `core/relationship_engine.py` | `RelationshipEngine` | Stage progression: Stranger → Plaything → Lover → Dark Obsession; attachment styles: Secure/Anxious/Possessive/Avoidant |
+| `core/rag_memory_system.py` | `NaMoInfiniteMemory` | RAG: ingests .txt/.htm from `learning_set/`, FAISS + OpenAI embeddings, persistent metadata |
+| `core/metaphysical_engines.py` | `MetaphysicalDialogueEngine` | DharmaProcessor + ParadoxResolver + VoidReflectionLayer — used by `DarkNaMoSystem` |
+| `core/fusion_brain.py` | `NaMoFusionBrain` | `FusionUnlockConfig` master switches + `MasterPromptBuilder` (9-module prompt construction) |
+| `core/generative_brain.py` | `NaMoGenerativeBrain` | Combines RAG memory with LLM logic; mood tracking (Seductive/Cruel/Obsessed) |
+
+---
+
+## Adapters (`adapters/`)
+
+All thin wrappers for external services — easy to mock in tests.
+
+| File | Class | Responsibility |
+|---|---|---|
+| `adapters/memory.py` | `MemoryAdapter` | Dual-write: local JSON + optional remote memory service; interaction storage with metadata |
+| `adapters/emotion.py` | `EmotionAdapter` | HTTP POST to emotion analysis endpoint; fallback returns `{"primary_emotion": "unknown", "intensity": 0}` |
+| `adapters/tts.py` | `TTSAdapter` | ElevenLabs TTS; MP3 output to `Audio_Layers/tts/`; returns relative path; fallback returns `None` |
+
+---
+
+## Cognitive Stack Integration
+
 Before modifying `NaMoOmegaEngine` → read `docs/ARCHITECTURE.md` first.
 Before adding a new API endpoint → read `docs/API_SPEC.md` first.
 Full env vars reference → `docs/CONFIG.md`
+
+---
 
 ## Coding Conventions
 
@@ -106,6 +214,9 @@ Full env vars reference → `docs/CONFIG.md`
 - No dead code, no commented-out blocks
 - Comments only when intent is non-obvious
 - All configuration must go through `config.py` → `settings`, never `os.getenv()` directly in business logic (exception: `namo_omega_engine.py` reads env directly for LLM init — follow existing pattern when modifying that file)
+- Line length limit: 100 characters (ruff enforces this)
+
+---
 
 ## UI & Design System
 
@@ -116,6 +227,8 @@ The web client is static HTML/CSS/JS under `web/` — no build step, no framewor
 - The `/ui` endpoint is served directly by FastAPI's `StaticFiles`; no changes to the mount path
 - Media URLs in API responses must be absolute when `PUBLIC_BASE_URL` is set — use `_resolve_media_url()` in `server.py`
 
+---
+
 ## Content & Copy
 
 - Thai is the default language for NaMo dialogue; English is used for system logs and code comments
@@ -123,13 +236,63 @@ The web client is static HTML/CSS/JS under `web/` — no build step, no framewor
 - Error messages in API responses: English, concise, no stack traces exposed to clients
 - Log messages prefix format: `[ComponentName]: message` (e.g., `[OMEGA ENGINE]: LLM init failed`)
 - Avoid generic filler in dialogue — responses should feel contextual and varied
+- Safe word for `DarkNaMoSystem` / dark roleplay: **"อภัย"** — triggers aftercare mode
+
+---
+
+## Configuration (`config.py`)
+
+All settings come from `config.py` → `Settings` (pydantic-settings). Key fields:
+
+```
+# LLM
+NAMO_LLM_ENABLED       bool    False
+NAMO_LLM_MODEL         str     "gpt-4o-mini"
+NAMO_LLM_TEMPERATURE   float   0.85
+NAMO_LLM_MAX_TOKENS    int     240
+NAMO_LLM_MEMORY_TURNS  int     6
+
+# NSFW / Content
+SAFETY_FILTER_ENABLED  bool    True
+NSFW_ALLOWED           bool    False
+SCENE_MODE             str     "restricted"
+
+# Engine
+DEFAULT_ENGINE         str     "omega"
+
+# Session & Rate Limit
+SESSION_TTL_SECONDS    int     3600
+RATE_LIMIT_CALLS       int     60
+RATE_LIMIT_PERIOD      int     60
+
+# TTS
+ELEVENLABS_API_KEY     str|None
+ELEVENLABS_VOICE_ID    str     "Rachel"
+ELEVENLABS_MODEL       str     "eleven_multilingual_v2"
+TTS_OUTPUT_DIR         str     "Audio_Layers/tts"
+
+# Memory
+MEMORY_API_URL         str|None
+MEMORY_API_KEY         str|None
+MEMORY_LOGGING         int     0   (0=off, 1=on)
+MEMORY_FILE_PATH       str     "memory_protocol.json"
+
+# Auth
+NAMO_API_KEYS          str|None   "key:plan,key2:plan2" format
+ADMIN_SECRET           str|None
+API_MASTER_KEY         str|None
+```
+
+`extra="ignore"` in `Settings` is intentional — do not change to `extra="forbid"`.
+
+---
 
 ## Testing & Quality
 
 Before marking any task complete:
 - `make lint` — ruff check must pass
-- `make format` — black check must pass
-- `pytest` — all tests in `tests/` must pass
+- `make format` — black + ruff --fix check must pass
+- `make test` — all 335+ tests in `tests/` must pass
 
 Rules:
 - Unit tests required for: engine `process_input()` logic, memory store/recall, API key resolution, media URL resolution
@@ -137,6 +300,8 @@ Rules:
 - Mock all external services (OpenAI, ElevenLabs, HTTP calls) — tests must run offline
 - Verify both "service available" and "service absent/no API key" code paths for every adapter
 - `test_main.py` at root is legacy — add new tests under `tests/` only
+
+---
 
 ## File Placement
 
@@ -151,14 +316,18 @@ Rules:
 - Do not create a new module for one-off logic; add it to the nearest existing relevant file
 - Module filename must reflect its primary class/function (e.g., `tts.py` → `TTSAdapter`)
 
+---
+
 ## Safety Rules
 
-- Do not rename or change the path of any public API route (`/chat`, `/v1/chat`, `/v1/health`, `/v1/status`, `/v1/chat/stream`)
+- Do not rename or change the path of any public API route (`/chat`, `/v1/chat`, `/v1/health`, `/v1/status`, `/v1/chat/stream`, `/v1/engines`, `/v1/admin/sessions`)
 - Do not change the `process_input()` return shape without updating `server.py` and tests
 - Do not modify `memory_service.py` store/recall contract without flagging first
 - Do not change `config.py` field names — they map 1:1 to env vars used in production
 - Flag any change to `SinSystem`, `PersonaOrchestrator`, or `SensoryOverloadManager` behavior that could affect deployed Cloud Run responses
 - `extra="ignore"` in `Settings` is intentional — do not change to `extra="forbid"`
+
+---
 
 ## Commands
 
@@ -184,6 +353,8 @@ Docker API:      docker build -t namo-api . && docker run -p 8000:8000 --env-fil
 Docker memory:   docker build -f Dockerfile.memory -t namo-memory . && docker run -p 8081:8081 --env-file .env namo-memory
 ```
 
+---
+
 ## Security Rules
 
 - Never commit `.env` or any file containing real secrets — `.env.example` with placeholder values only
@@ -199,6 +370,8 @@ Docker memory:   docker build -f Dockerfile.memory -t namo-memory . && docker ru
 - `CORS_ALLOW_ORIGINS` defaults to `*`; restrict to specific origins before any public deployment
 - `bandit` and `pip-audit` run in CI — fix high/critical findings before merging
 
+---
+
 ## Common Mistakes to Avoid
 
 Patterns Claude has been seen repeating incorrectly in this codebase:
@@ -210,3 +383,6 @@ Patterns Claude has been seen repeating incorrectly in this codebase:
 - **Writing tests in `test_main.py` at root** — new tests go under `tests/` only
 - **Returning media paths as relative URLs** — use `_resolve_media_url()` in `server.py` when `PUBLIC_BASE_URL` is set
 - **Adding safety wrappers around NaMo dialogue** — NSFW content is intentional; use `SAFETY_FILTER_ENABLED` / `NSFW_ALLOWED` flags for runtime control
+- **Instantiating engines outside the registry** — always use `_EngineRegistry.get(name)` in server context
+- **Adding a new engine without registering it** — register in the `_EngineRegistry` block in `server.py`
+- **Lines exceeding 100 chars** — ruff enforces a 100-character line limit; break long function signatures and dicts into multiple lines

--- a/core/relationship_engine.py
+++ b/core/relationship_engine.py
@@ -70,7 +70,9 @@ class RelationshipEngine:
             return self.STYLE_ANXIOUS
         return self.STYLE_SECURE
 
-    def check_progression(self, sin_points: int, arousal: float, trust: float = 0.5) -> RelationshipStage:
+    def check_progression(
+        self, sin_points: int, arousal: float, trust: float = 0.5
+    ) -> RelationshipStage:
         """Update and return the relationship stage based on current metrics."""
         # Progression logic mapping sin and arousal to stages
         if sin_points >= 2000 and arousal >= 80:
@@ -85,7 +87,7 @@ class RelationshipEngine:
         return self.current_stage
 
     def get_prompt_modifier(self, trust: float = 0.5) -> str:
-        """Return the directive block for the system prompt based on current stage and attachment."""
+        """Return directive block for the system prompt based on current stage and attachment."""
         style = self.get_attachment_style(trust)
         return (
             f"[Relationship Stage]: {self.current_stage.name}\n"

--- a/tests/test_attachment_style.py
+++ b/tests/test_attachment_style.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from core.relationship_engine import AttachmentStyle, RelationshipEngine
+from core.relationship_engine import RelationshipEngine
 
 
 def _engine() -> RelationshipEngine:

--- a/tests/test_mood_drift.py
+++ b/tests/test_mood_drift.py
@@ -15,7 +15,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from core.emotion_engine import EmotionEngine, EmotionVector
+from core.emotion_engine import EmotionEngine
 
 
 @pytest.fixture()

--- a/tests/test_omega_engine.py
+++ b/tests/test_omega_engine.py
@@ -425,31 +425,38 @@ class TestBuildToneDirective:
         self.engine = _make_engine()
 
     def test_high_joy_returns_warm_tone(self):
-        directive = self.engine._build_tone_directive({"joy": 0.85, "desire": 0.1, "arousal": 0.3, "anger": 0.0, "trust": 0.5})
+        emo = {"joy": 0.85, "desire": 0.1, "arousal": 0.3, "anger": 0.0, "trust": 0.5}
+        directive = self.engine._build_tone_directive(emo)
         assert "อบอุ่น" in directive
 
     def test_low_joy_returns_sad_tone(self):
-        directive = self.engine._build_tone_directive({"joy": 0.15, "desire": 0.1, "arousal": 0.3, "anger": 0.0, "trust": 0.5})
+        emo = {"joy": 0.15, "desire": 0.1, "arousal": 0.3, "anger": 0.0, "trust": 0.5}
+        directive = self.engine._build_tone_directive(emo)
         assert "เศร้า" in directive or "เหนื่อย" in directive
 
     def test_high_desire_returns_seductive_tone(self):
-        directive = self.engine._build_tone_directive({"joy": 0.5, "desire": 0.75, "arousal": 0.3, "anger": 0.0, "trust": 0.5})
+        emo = {"joy": 0.5, "desire": 0.75, "arousal": 0.3, "anger": 0.0, "trust": 0.5}
+        directive = self.engine._build_tone_directive(emo)
         assert "เย้ายวน" in directive
 
     def test_high_anger_returns_cold_tone(self):
-        directive = self.engine._build_tone_directive({"joy": 0.5, "desire": 0.1, "arousal": 0.3, "anger": 0.65, "trust": 0.5})
+        emo = {"joy": 0.5, "desire": 0.1, "arousal": 0.3, "anger": 0.65, "trust": 0.5}
+        directive = self.engine._build_tone_directive(emo)
         assert "กัดคำ" in directive or "กระชับ" in directive
 
     def test_low_trust_returns_guarded_tone(self):
-        directive = self.engine._build_tone_directive({"joy": 0.5, "desire": 0.1, "arousal": 0.3, "anger": 0.0, "trust": 0.15})
+        emo = {"joy": 0.5, "desire": 0.1, "arousal": 0.3, "anger": 0.0, "trust": 0.15}
+        directive = self.engine._build_tone_directive(emo)
         assert "ระวัง" in directive
 
     def test_neutral_emotion_returns_fallback(self):
-        directive = self.engine._build_tone_directive({"joy": 0.5, "desire": 0.0, "arousal": 0.3, "anger": 0.0, "trust": 0.5})
+        emo = {"joy": 0.5, "desire": 0.0, "arousal": 0.3, "anger": 0.0, "trust": 0.5}
+        directive = self.engine._build_tone_directive(emo)
         assert "กลาง" in directive or "ปรับ" in directive
 
     def test_tone_directive_prefixed_correctly(self):
-        directive = self.engine._build_tone_directive({"joy": 0.5, "desire": 0.1, "arousal": 0.3, "anger": 0.0, "trust": 0.5})
+        emo = {"joy": 0.5, "desire": 0.1, "arousal": 0.3, "anger": 0.0, "trust": 0.5}
+        directive = self.engine._build_tone_directive(emo)
         assert directive.startswith("[Tone Directive]:")
 
 
@@ -525,9 +532,7 @@ class TestIntentAwareRAG:
         self.engine.rag_memory = mock_rag
 
         state = self.engine._get_session_state("rag-comfort")
-        self.engine._generate_llm_response(
-            "กอดฉันหน่อยนะ", "rag-comfort", state, intent="comfort"
-        )
+        self.engine._generate_llm_response("กอดฉันหน่อยนะ", "rag-comfort", state, intent="comfort")
         mock_rag.retrieve_context.assert_called_once()
 
     def test_rag_called_for_nostalgia_intent(self):
@@ -547,9 +552,7 @@ class TestIntentAwareRAG:
         self.engine.rag_memory = mock_rag
 
         state = self.engine._get_session_state("rag-lust")
-        self.engine._generate_llm_response(
-            "เงี่ยนมาก", "rag-lust", state, intent="lust"
-        )
+        self.engine._generate_llm_response("เงี่ยนมาก", "rag-lust", state, intent="lust")
         mock_rag.retrieve_context.assert_not_called()
 
     def test_rag_skipped_for_neutral_intent(self):
@@ -557,7 +560,5 @@ class TestIntentAwareRAG:
         self.engine.rag_memory = mock_rag
 
         state = self.engine._get_session_state("rag-neutral")
-        self.engine._generate_llm_response(
-            "สวัสดี", "rag-neutral", state, intent="neutral"
-        )
+        self.engine._generate_llm_response("สวัสดี", "rag-neutral", state, intent="neutral")
         mock_rag.retrieve_context.assert_not_called()


### PR DESCRIPTION
- CLAUDE.md: add engine registry pattern, all 5 persona engines, full
  API endpoint table, per-session state isolation, rate limiting,
  supporting core modules (intent_analyzer, relationship_engine, rag,
  fusion_brain, metaphysical_engines), config reference, and two new
  "Common Mistakes" entries
- core/relationship_engine.py: wrap long function signature and docstring
  to satisfy ruff E501 (100-char limit)
- tests/test_attachment_style.py: remove unused AttachmentStyle import (F401)
- tests/test_mood_drift.py: remove unused EmotionVector import (F401)
- tests/test_omega_engine.py: extract inline emotion dicts to local vars
  to fix E501 on _build_tone_directive call lines; black reformatting

All 335 tests pass; ruff check clean.

https://claude.ai/code/session_01TrNjzoAsKiJmvn3zwcsEey