### PR TITLE
Add tests for /api/dream endpoint

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -525,12 +525,9 @@ def test_dream_triggers_hypothesis_when_engine_available():
 def test_dream_returns_error_payload_on_failure():
     """POST /api/dream returns an error payload instead of raising when scheduling fails."""
     mock_engine = MagicMock()
+    mock_engine.generate_hypothesis.side_effect = RuntimeError("loop closed")
 
-    with (
-        patch("server.settings") as mock_settings,
-        patch("server.asi_engine", mock_engine),
-        patch("server.asyncio.create_task", side_effect=RuntimeError("loop closed")),
-    ):
+    with patch("server.settings") as mock_settings, patch("server.asi_engine", mock_engine):
         mock_settings.admin_secret = None
         response = client.post("/api/dream")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -483,6 +483,64 @@ def test_engine_status_endpoint():
 
 
 # ---------------------------------------------------------------------------
+# /api/dream endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_dream_returns_403_with_wrong_admin_secret():
+    """POST /api/dream returns 403 when ADMIN_SECRET is set and header is wrong."""
+    with patch("server.settings") as mock_settings:
+        mock_settings.admin_secret = "correct-secret"
+        response = client.post("/api/dream", headers={"x-admin-secret": "wrong"})
+    assert response.status_code == 403
+
+
+def test_dream_reports_missing_engine():
+    """POST /api/dream returns a graceful payload when the ASI engine is unavailable."""
+    with patch("server.settings") as mock_settings, patch("server.asi_engine", None):
+        mock_settings.admin_secret = None
+        response = client.post("/api/dream")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ASI engine not initialized"
+    assert data["error"] == "dependencies_missing"
+
+
+def test_dream_triggers_hypothesis_when_engine_available():
+    """POST /api/dream schedules hypothesis generation when the ASI engine is loaded."""
+    from unittest.mock import AsyncMock
+
+    mock_engine = MagicMock()
+    mock_engine.generate_hypothesis = AsyncMock(return_value={"hypothesis": "test"})
+
+    with patch("server.settings") as mock_settings, patch("server.asi_engine", mock_engine):
+        mock_settings.admin_secret = None
+        response = client.post("/api/dream")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "NaMo is dreaming and researching..."}
+    mock_engine.generate_hypothesis.assert_called_once()
+
+
+def test_dream_returns_error_payload_on_failure():
+    """POST /api/dream returns an error payload instead of raising when scheduling fails."""
+    mock_engine = MagicMock()
+
+    with (
+        patch("server.settings") as mock_settings,
+        patch("server.asi_engine", mock_engine),
+        patch("server.asyncio.create_task", side_effect=RuntimeError("loop closed")),
+    ):
+        mock_settings.admin_secret = None
+        response = client.post("/api/dream")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert "loop closed" in data["detail"]
+
+
+# ---------------------------------------------------------------------------
 # Per-request engine override
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements the "Missing test for /api/dream" TODO flagged in `FIXES_APPLIED.md` (Known Remaining Issues #3) and `TESTING_REPORT.md`. The endpoint previously had zero test coverage.

Adds four tests to `tests/test_server.py` covering every branch of the `/api/dream` handler:

- **Admin auth**: returns 403 when `ADMIN_SECRET` is configured and the `X-Admin-Secret` header is wrong
- **Engine missing**: returns the graceful `{"status": "ASI engine not initialized", "error": "dependencies_missing"}` payload when `asi_engine` is `None`
- **Success path**: schedules `generate_hypothesis()` (mocked via `AsyncMock`) and returns the "dreaming" status
- **Error path**: returns `{"status": "error", "detail": ...}` instead of raising when task creation fails

All external dependencies are mocked, so the tests run offline — no Qdrant/Neo4j/OpenAI required, consistent with the existing test suite conventions.

## Testing

- `pytest tests/test_server.py` — 33 passed (29 existing + 4 new)
- `ruff check` — passes
- `black --check` — passes (black also normalized a few pre-existing blank-line spots in the same file)
- Pre-existing failures in `tests/test_rag_memory.py` / `tests/test_tts_adapter.py` are environment-related (missing optional deps) and fail identically on `main` without this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a)_