### PR TITLE
Phase 1 (step 1): ROADMAP.md + structured logging

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,128 @@
+# ROADMAP.md - NaMo Forbidden Archive
+
+**เวอร์ชัน:** 1.0
+**วันที่:** 2026-07-09
+**เป้าหมาย:** ทำให้โปรเจกต์ใช้งานได้จริง + พร้อมนำไปขายเชิงพาณิชย์ (Commercial Ready)
+
+---
+
+## ภาพรวม
+NaMo Forbidden Archive เป็นระบบ AI Persona สำหรับบทสนทนาแบบผู้ใหญ่/NSFW ที่มี Emotion Engine, Memory RAG และ Multi-Persona
+
+**สถานะปัจจุบัน:** ยังอยู่ในขั้นพัฒนา (มีโค้ดพื้นฐาน แต่ยังไม่ Production Ready และยังไม่พร้อมขาย)
+
+---
+
+## Roadmap ทั้งหมด (5 Phases)
+
+### **Phase 0: เตรียมพื้นฐาน** (1-3 วัน)
+- [x] อ่านเอกสารทั้งหมด (CLAUDE.md, README.md, INSTALL_GUIDE.md, ARCHITECTURE.md)
+- [x] Clone repo และตั้งค่า `.env` จาก `.env.example`
+- [x] ติดตั้ง dependencies และรันได้ทั้ง CLI (`app.py`) และ REST API (`server.py`)
+- [x] รัน `make lint`, `make format`, `make test` และแก้ไขข้อผิดพลาด (ผ่านครบ 5 gate, 344 tests)
+- [x] ทดสอบ Web UI (`/ui`)
+
+**สถานะ:** ✅ เสร็จ
+
+---
+
+### **Phase 1: ทำให้เสถียรและ Production Ready** (1-2 สัปดาห์)
+
+**โค้ดและคุณภาพ**
+- [x] Refactor โค้ดหลักให้ตรง PEP 8 (black + ruff) — CI เขียวครบ
+- [ ] แก้ Bug และเพิ่ม Error Handling ที่เหมาะสม (ก้าว 3)
+- [x] เพิ่ม Structured Logging — `config.setup_logging()` + entry points `server.py`/`memory_service.py`
+- [ ] เพิ่ม/ปรับ Unit Test ให้ครอบคลุมมากขึ้น (ก้าว 4; ปัจจุบัน 344 tests)
+- [~] แยก Configuration สำหรับ Production / Development — `debug`/`log_level` คุม logging แล้ว, เหลือ error-detail/prod hardening
+
+**ระบบ**
+- [ ] ทำให้ Docker + docker-compose ใช้งานได้สมบูรณ์ (ก้าว 2 — ปัจจุบัน compose มีแค่ qdrant/neo4j)
+- [x] แยก Memory Service เป็น microservice — `memory_service.py` + `Dockerfile.memory`
+- [x] เพิ่ม Security (Rate Limiting, CORS, Admin Secret, API Key)
+- [x] เพิ่ม Session Management และ Auto Cleanup — `SESSION_TTL_SECONDS` + cleanup loop
+- [x] เพิ่ม Health Check + Monitoring — `/v1/health`, `/v1/status` (monitoring เพิ่มเติมทีหลัง)
+
+**Deliverable:** Docker image ที่เสถียร + API ที่พร้อมใช้งาน
+
+**สถานะ:** 🟡 กำลังทำ (~75%) — ก้าว 1 (Structured Logging) เสร็จ; เหลือ Docker Compose, Error Handling, Tests
+
+---
+
+### **Phase 2: ปรับปรุงประสบการณ์ผู้ใช้ (UX/UI)** (1-2 สัปดาห์)
+- [ ] ปรับ Web UI ให้สวยงาม ทันสมัย และ Responsive
+- [ ] เพิ่มฟีเจอร์ History, Settings, Persona Switch
+- [ ] เพิ่ม Voice Input/Output (Whisper + ElevenLabs)
+- [ ] สร้าง Landing Page สำหรับขาย
+- [ ] เพิ่ม Age Gate / Content Warning
+
+**Deliverable:** เว็บแอพที่ใช้งานง่ายและดูเป็นผลิตภัณฑ์
+
+**สถานะ:** ⬜ ยังไม่ทำ
+
+---
+
+### **Phase 3: ความปลอดภัย กฎหมาย และระบบการขาย** (2-3 สัปดาห์)
+
+**Security**
+- [ ] เพิ่ม Authentication (JWT / API Key Management)
+- [ ] Encryption สำหรับข้อมูล敏感
+- [ ] Audit Log
+- [ ] Security Scan (bandit, pip-audit)
+
+**กฎหมาย**
+- [ ] เขียน Terms of Service, Privacy Policy, Disclaimer (18+)
+- [ ] ระบบยืนยันอายุ (Age Verification)
+- [ ] ตรวจสอบกฎหมายที่เกี่ยวข้อง
+
+**ระบบขาย**
+- [ ] เพิ่ม Subscription System (Stripe / Paddle)
+- [ ] Feature Flag (Lite / Pro / Enterprise)
+- [ ] Multi-tenant Support
+
+**Deliverable:** ระบบพร้อมขาย + เอกสารทางกฎหมายครบถ้วน
+
+**สถานะ:** ⬜ ยังไม่ทำ
+
+---
+
+### **Phase 4: Marketing & Launch** (1-2 สัปดาห์)
+- [ ] สร้าง Landing Page + Demo ที่สวยงาม
+- [ ] ทำ Video Demo การใช้งาน
+- [ ] เขียน Documentation สำหรับลูกค้า
+- [ ] ตั้งราคาและแผนการขาย
+- [ ] เตรียมช่องทางการขาย (เว็บ, Gumroad, Patreon)
+- [ ] Beta Testing กับกลุ่มผู้ใช้
+
+**Deliverable:** เปิดขายได้จริง
+
+**สถานะ:** ⬜ ยังไม่ทำ
+
+---
+
+### **Phase 5: หลัง Launch (Ongoing)**
+- [ ] เก็บ Feedback และแก้ไขต่อเนื่อง
+- [ ] เพิ่มฟีเจอร์ใหม่ (Image Generation, Mobile Support ฯลฯ)
+- [ ] ปรับ Scaling และ Performance
+- [ ] Marketing และ Community Building
+
+---
+
+## ลำดับความสำคัญในการเริ่มงาน
+1. **Phase 0** → **Phase 1** (ต้องทำให้เสถียรก่อน)
+2. Phase 3 (Security + Monetization) สำคัญมากเพราะเป็น NSFW
+3. ทำทีละ Phase และทดสอบให้ผ่านก่อนไป Phase ถัดไป
+
+---
+
+**แนวทางการทำงานกับ Agent:**
+- ให้ Agent อ่านไฟล์นี้ก่อนทุกครั้ง
+- ทำงานตามลำดับ Phase
+- รายงานความคืบหน้าทุก Phase
+- Follow CLAUDE.md และ PEP 8 อย่างเคร่งครัด
+
+---
+
+**ติดตามความคืบหน้า:**
+อัพเดทสถานะในไฟล์นี้เป็นประจำ (ใช้ [x] เมื่อเสร็จ)
+
+---

--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+import logging
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -86,3 +88,24 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+def setup_logging(level: str | None = None) -> None:
+    """Configure root logging from settings.
+
+    In development (``settings.debug`` True) the level floor is DEBUG; otherwise
+    it honors ``settings.log_level`` (or an explicit ``level`` override). Safe to
+    call more than once — reconfigures the root handler idempotently.
+
+    Log messages keep the ``[ComponentName]: message`` convention in their text;
+    the formatter adds timestamp, level, and logger name around it.
+    """
+    resolved = (level or settings.log_level or "INFO").upper()
+    numeric_level = getattr(logging, resolved, logging.INFO)
+    if settings.debug:
+        numeric_level = logging.DEBUG
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        force=True,
+    )

--- a/memory_service.py
+++ b/memory_service.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from datetime import datetime
 from threading import Lock
@@ -6,7 +7,10 @@ from threading import Lock
 from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from config import settings
+from config import settings, setup_logging
+
+setup_logging()
+logger = logging.getLogger("namo.memory")
 
 # --- Pydantic Models based on OpenAPI Spec ---
 
@@ -94,7 +98,7 @@ class MemoryManager:
             A dictionary containing the loaded memory data.
         """
         if not os.path.exists(self.file_path):
-            print(f"[!] Memory file not found, creating new one: {self.file_path}")
+            logger.info("[MemoryService]: creating new memory file: %s", self.file_path)
             # Added a top-level key to store records
             return {"records": [], "protocol_metadata": {}}
         with open(self.file_path, encoding="utf-8") as f:
@@ -285,4 +289,4 @@ async def health_check(manager: MemoryManager = Depends(get_memory_manager)):  #
     return {"status": "ok", "memory_records": len(manager.memory.get("records", []))}
 
 
-print("Memory Service script created. Ready to be run with Uvicorn.")
+logger.info("[MemoryService]: module loaded; ready to run with Uvicorn.")

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import time
 import uuid
 from collections import defaultdict
@@ -17,7 +18,10 @@ from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from config import settings
+from config import settings, setup_logging
+
+setup_logging()
+logger = logging.getLogger("namo.server")
 from core.base_persona import BasePersonaEngine
 from core.dark_system import DarkNaMoSystem
 from core.namo_omega_engine import NaMoOmegaEngine
@@ -127,7 +131,7 @@ class _EngineRegistry:
                 detail=f"unknown_engine '{name}'. available: {cls.available()}",
             )
         if name not in cls._instances:
-            print(f"[EngineRegistry]: loading '{name}'...")
+            logger.info(f"[EngineRegistry]: loading '{name}'...")
             cls._instances[name] = cls._constructors[name]()
         return cls._instances[name]
 
@@ -144,7 +148,7 @@ _EngineRegistry.register("dark", DarkNaMoSystem)
 _EngineRegistry.register("ultimate", NaMoUltimateBrain)
 
 # Pre-load default engine at startup
-print("[System]: Awakening NaMo Omega...")
+logger.info("[System]: Awakening NaMo Omega...")
 engine = _EngineRegistry.get(settings.default_engine)
 
 # Optional: ASI Simulation Engine (graceful fallback if dependencies missing)
@@ -152,7 +156,7 @@ asi_engine = None
 try:
     from core.engines.asi_simulation_engine import asi_engine
 except ImportError as err:
-    print(f"[Warning]: ASI Simulation Engine not available ({err})")
+    logger.warning(f"[Warning]: ASI Simulation Engine not available ({err})")
 
 
 @app.post("/api/dream")
@@ -168,7 +172,7 @@ async def trigger_dream(x_admin_secret: str | None = Header(default=None)):
         asyncio.create_task(asi_engine.generate_hypothesis())
         return {"status": "NaMo is dreaming and researching..."}
     except Exception as exc:
-        print(f"[Dream]: Error: {exc}")
+        logger.error(f"[Dream]: Error: {exc}")
         return {"status": "error", "detail": str(exc)}
 
 
@@ -233,7 +237,7 @@ def _store_memory_if_enabled(
     try:
         requests.post(memory_url, json=payload, headers=headers, timeout=2)
     except requests.RequestException as exc:
-        print(f"[MemoryLog]: Failed to store memory: {exc}")
+        logger.warning(f"[MemoryLog]: Failed to store memory: {exc}")
 
 
 def _parse_api_key_map(raw: str | None) -> dict[str, str]:
@@ -274,7 +278,7 @@ def _log_usage(event: dict) -> None:
         with open(path, "a", encoding="utf-8") as handle:
             handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
     except OSError as exc:
-        print(f"[UsageLog]: Failed to write usage event: {exc}")
+        logger.warning(f"[UsageLog]: Failed to write usage event: {exc}")
 
 
 def _get_base_url(request: Request) -> str:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,42 @@
+"""Tests for config.setup_logging — no network or filesystem required."""
+
+import logging
+from unittest.mock import patch
+
+from config import setup_logging
+
+
+def test_debug_true_forces_debug_level():
+    """In development (debug=True) the root level floor is DEBUG."""
+    with patch("config.settings") as mock_settings:
+        mock_settings.debug = True
+        mock_settings.log_level = "INFO"
+        setup_logging()
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_honors_log_level_when_not_debug():
+    """In production (debug=False) the configured log_level is honored."""
+    with patch("config.settings") as mock_settings:
+        mock_settings.debug = False
+        mock_settings.log_level = "WARNING"
+        setup_logging()
+    assert logging.getLogger().level == logging.WARNING
+
+
+def test_invalid_level_falls_back_to_info():
+    """An unrecognized log_level falls back to INFO (not a crash)."""
+    with patch("config.settings") as mock_settings:
+        mock_settings.debug = False
+        mock_settings.log_level = "NOT_A_LEVEL"
+        setup_logging()
+    assert logging.getLogger().level == logging.INFO
+
+
+def test_explicit_level_override():
+    """An explicit level argument overrides settings.log_level."""
+    with patch("config.settings") as mock_settings:
+        mock_settings.debug = False
+        mock_settings.log_level = "INFO"
+        setup_logging("ERROR")
+    assert logging.getLogger().level == logging.ERROR


### PR DESCRIPTION
## Summary

First step of **Phase 1** (make the project stable / production-ready) per `ROADMAP.md`. This PR also **adds `ROADMAP.md`** itself as the phase-by-phase source of truth.

Phase 1 was already ~65% complete from earlier work (PEP8/CI green, security, session mgmt + cleanup, memory microservice, health checks). The clear remaining gap tackled here is **structured logging** — the app was using `print()` everywhere, and the `app_env` / `debug` / `log_level` config fields existed but were never actually used.

## Changes

- **`config.setup_logging()`** — configures root logging from `settings`. DEBUG floor when `settings.debug` is `True` (development); otherwise honors `settings.log_level`. This wires the previously-dead `debug` / `log_level` config into real behaviour (partial progress on the "prod/dev config" item too).
- **`server.py`** + **`memory_service.py`** — call `setup_logging()` at startup and replace every `print()` with module loggers (`namo.server` / `namo.memory`), keeping the documented `[ComponentName]: message` convention in the log text so existing log greps still work.
- **`tests/test_logging_config.py`** — 4 tests: DEBUG floor in dev, `log_level` honored in prod, invalid-level fallback to INFO, explicit override.
- **`ROADMAP.md`** — added; Phase 0 marked complete, Phase 1 status updated to ~75% with per-item annotations.

No route paths or `process_input()` contracts touched.

## Testing

Full `build-test` sequence, all green locally:
- `ruff check .` — pass
- `black --check .` — pass
- `pytest` — **344 passed** (340 + 4 new)
- `pip-audit` — no known vulnerabilities
- `bandit -r .` — 0 issues
- Runtime smoke: `setup_logging()` emits `2026-... [INFO] namo.server: [System]: ...`; `debug=True` → root level DEBUG ✓

## Phase 1 remaining (next steps, separate PRs)
2. Complete `docker-compose` (add `api` + `memory` services)
3. Error-handling consistency + client-safe error responses
4. Additional unit-test coverage

Per the ROADMAP workflow I'll pause for confirmation before starting the next Phase 1 step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a)_