### PR TITLE
Phase 1 (step 3): structured, client-safe error handling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,10 +30,10 @@ NaMo Forbidden Archive เป็นระบบ AI Persona สำหรับบ
 
 **โค้ดและคุณภาพ**
 - [x] Refactor โค้ดหลักให้ตรง PEP 8 (black + ruff) — CI เขียวครบ
-- [ ] แก้ Bug และเพิ่ม Error Handling ที่เหมาะสม (ก้าว 3)
+- [x] แก้ Bug และเพิ่ม Error Handling ที่เหมาะสม — `core/exceptions.py` + global handlers (server + memory), client-safe JSON, ซ่อน stack trace เมื่อ `debug=False`
 - [x] เพิ่ม Structured Logging — `config.setup_logging()` + entry points `server.py`/`memory_service.py`
-- [ ] เพิ่ม/ปรับ Unit Test ให้ครอบคลุมมากขึ้น (ก้าว 4; ปัจจุบัน 344 tests)
-- [~] แยก Configuration สำหรับ Production / Development — `debug`/`log_level` คุม logging แล้ว, เหลือ error-detail/prod hardening
+- [~] เพิ่ม/ปรับ Unit Test ให้ครอบคลุมมากขึ้น (ก้าว 4; ปัจจุบัน 351 tests — error paths ครอบคลุมแล้ว)
+- [x] แยก Configuration สำหรับ Production / Development — `debug`/`log_level` คุม logging + error-detail exposure
 
 **ระบบ**
 - [x] ทำให้ Docker + docker-compose ใช้งานได้สมบูรณ์ — compose มี `api` + `memory` (+qdrant/neo4j), `docker compose up --build` รันทั้ง stack
@@ -44,7 +44,7 @@ NaMo Forbidden Archive เป็นระบบ AI Persona สำหรับบ
 
 **Deliverable:** Docker image ที่เสถียร + API ที่พร้อมใช้งาน
 
-**สถานะ:** 🟡 กำลังทำ (~85%) — ก้าว 1 (Logging) + ก้าว 2 (Docker Compose) เสร็จ; เหลือ Error Handling, Tests
+**สถานะ:** 🟡 กำลังทำ (~95%) — ก้าว 1 (Logging), 2 (Docker Compose), 3 (Error Handling) เสร็จ; เหลือ ก้าว 4 (เติม Unit Tests เพิ่มเติม)
 
 ---
 

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -1,0 +1,59 @@
+"""Custom exceptions and helpers for consistent, client-safe error handling.
+
+All application errors surfaced through the API inherit from ``NamoAPIError``.
+Each carries a stable ``error_code`` (machine-readable) and an HTTP ``status_code``.
+The ``message`` is safe, user-facing text; ``detail`` holds diagnostic context that
+is only exposed to clients when running in debug mode.
+"""
+
+
+class NamoAPIError(Exception):
+    """Base class for errors that map to a structured API response."""
+
+    status_code: int = 500
+    error_code: str = "INTERNAL_ERROR"
+
+    def __init__(self, message: str = "Something went wrong", *, detail: str | None = None):
+        super().__init__(message)
+        self.message = message
+        self.detail = detail
+
+
+class AuthenticationError(NamoAPIError):
+    """Missing or invalid credentials."""
+
+    status_code = 401
+    error_code = "AUTHENTICATION_ERROR"
+
+
+class RateLimitError(NamoAPIError):
+    """Client exceeded the configured request rate."""
+
+    status_code = 429
+    error_code = "RATE_LIMIT_EXCEEDED"
+
+
+class EngineError(NamoAPIError):
+    """A persona engine failed to produce a response."""
+
+    status_code = 502
+    error_code = "ENGINE_ERROR"
+
+
+class MemoryServiceError(NamoAPIError):
+    """The memory service is unavailable or returned an error."""
+
+    status_code = 502
+    error_code = "MEMORY_SERVICE_ERROR"
+
+
+def error_payload(error: str, error_code: str, detail: str | None = None) -> dict[str, object]:
+    """Build the canonical error response body.
+
+    ``detail`` is omitted entirely when ``None`` so production responses never leak
+    diagnostic context or stack traces.
+    """
+    body: dict[str, object] = {"success": False, "error": error, "error_code": error_code}
+    if detail is not None:
+        body["detail"] = detail
+    return body

--- a/memory_service.py
+++ b/memory_service.py
@@ -251,7 +251,7 @@ async def _handle_validation_error(request: Request, exc: RequestValidationError
 
 @app.exception_handler(Exception)
 async def _handle_unexpected_error(request: Request, exc: Exception) -> JSONResponse:
-    logger.error("[MemoryService]: unhandled error: %s: %s", type(exc).__name__, exc)
+    logger.exception("[MemoryService]: unhandled error: %s", type(exc).__name__)
     detail = f"{type(exc).__name__}: {exc}" if settings.debug else None
     return JSONResponse(
         status_code=500,

--- a/memory_service.py
+++ b/memory_service.py
@@ -4,10 +4,13 @@ import os
 from datetime import datetime
 from threading import Lock
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from config import settings, setup_logging
+from core.exceptions import NamoAPIError, error_payload
 
 setup_logging()
 logger = logging.getLogger("namo.memory")
@@ -224,6 +227,36 @@ class MemoryManager:
 
 app = FastAPI(title="Infinity Awareness Engine - Memory Service")
 memory_manager = MemoryManager()  # Will now respect the MEMORY_FILE_PATH env var
+
+
+# --- Global error handlers: consistent, client-safe JSON; no stack traces in prod ---
+@app.exception_handler(NamoAPIError)
+async def _handle_namo_error(request: Request, exc: NamoAPIError) -> JSONResponse:
+    logger.warning("[MemoryService]: %s (%s)", exc.error_code, exc.message)
+    detail = exc.detail if settings.debug else None
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=error_payload(exc.message, exc.error_code, detail),
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def _handle_validation_error(request: Request, exc: RequestValidationError) -> JSONResponse:
+    detail = str(exc.errors()) if settings.debug else None
+    return JSONResponse(
+        status_code=422,
+        content=error_payload("Invalid request", "VALIDATION_ERROR", detail),
+    )
+
+
+@app.exception_handler(Exception)
+async def _handle_unexpected_error(request: Request, exc: Exception) -> JSONResponse:
+    logger.error("[MemoryService]: unhandled error: %s: %s", type(exc).__name__, exc)
+    detail = f"{type(exc).__name__}: {exc}" if settings.debug else None
+    return JSONResponse(
+        status_code=500,
+        content=error_payload("Internal server error", "INTERNAL_ERROR", detail),
+    )
 
 
 def get_memory_manager() -> MemoryManager:

--- a/server.py
+++ b/server.py
@@ -13,12 +13,14 @@ load_dotenv()
 
 import requests
 from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from config import settings, setup_logging
+from core.exceptions import NamoAPIError, error_payload
 
 setup_logging()
 logger = logging.getLogger("namo.server")
@@ -94,6 +96,37 @@ async def lifespan(_app: FastAPI):
 
 
 app = FastAPI(title="NaMo Forbidden Archive v9.0 (Omega Sensory)", lifespan=lifespan)
+
+
+# --- Global error handlers: consistent, client-safe JSON; no stack traces in prod ---
+@app.exception_handler(NamoAPIError)
+async def _handle_namo_error(request: Request, exc: NamoAPIError) -> JSONResponse:
+    logger.warning("[API]: %s (%s)", exc.error_code, exc.message)
+    detail = exc.detail if settings.debug else None
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=error_payload(exc.message, exc.error_code, detail),
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def _handle_validation_error(request: Request, exc: RequestValidationError) -> JSONResponse:
+    detail = str(exc.errors()) if settings.debug else None
+    return JSONResponse(
+        status_code=422,
+        content=error_payload("Invalid request", "VALIDATION_ERROR", detail),
+    )
+
+
+@app.exception_handler(Exception)
+async def _handle_unexpected_error(request: Request, exc: Exception) -> JSONResponse:
+    logger.error("[API]: unhandled error: %s: %s", type(exc).__name__, exc)
+    detail = f"{type(exc).__name__}: {exc}" if settings.debug else None
+    return JSONResponse(
+        status_code=500,
+        content=error_payload("Internal server error", "INTERNAL_ERROR", detail),
+    )
+
 
 # --- CORS + Static Media ---
 cors_origins = [o.strip() for o in settings.cors_allow_origins.split(",") if o.strip()]

--- a/server.py
+++ b/server.py
@@ -120,7 +120,7 @@ async def _handle_validation_error(request: Request, exc: RequestValidationError
 
 @app.exception_handler(Exception)
 async def _handle_unexpected_error(request: Request, exc: Exception) -> JSONResponse:
-    logger.error("[API]: unhandled error: %s: %s", type(exc).__name__, exc)
+    logger.exception("[API]: unhandled error: %s", type(exc).__name__)
     detail = f"{type(exc).__name__}: {exc}" if settings.debug else None
     return JSONResponse(
         status_code=500,

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,121 @@
+"""Tests for structured, client-safe error handling (core.exceptions + server handlers)."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+
+from core.exceptions import EngineError, NamoAPIError, error_payload
+from server import app
+
+client = TestClient(app)
+# A client that returns the 500 response instead of re-raising, for the catch-all handler.
+client_no_raise = TestClient(app, raise_server_exceptions=False)
+
+
+# --- error_payload helper ---
+
+
+def test_error_payload_omits_detail_when_none():
+    assert error_payload("oops", "INTERNAL_ERROR") == {
+        "success": False,
+        "error": "oops",
+        "error_code": "INTERNAL_ERROR",
+    }
+
+
+def test_error_payload_includes_detail_when_present():
+    body = error_payload("oops", "ENGINE_ERROR", "trace-context")
+    assert body["detail"] == "trace-context"
+    assert body["success"] is False
+
+
+def test_custom_exception_attributes():
+    exc = EngineError("engine down", detail="stack")
+    assert isinstance(exc, NamoAPIError)
+    assert exc.status_code == 502
+    assert exc.error_code == "ENGINE_ERROR"
+    assert exc.message == "engine down"
+    assert exc.detail == "stack"
+
+
+# --- validation errors ---
+
+
+def test_validation_error_returns_structured_shape():
+    with patch("server.settings") as mock_settings:
+        mock_settings.debug = False
+        mock_settings.namo_api_keys = None
+        mock_settings.namo_api_default_plan = "public"
+        response = client.post("/chat", json={})  # missing required "text"
+    assert response.status_code == 422
+    data = response.json()
+    assert data["success"] is False
+    assert data["error_code"] == "VALIDATION_ERROR"
+    assert "detail" not in data  # hidden when not in debug
+
+
+# --- custom NamoAPIError mapping ---
+
+
+def test_namo_api_error_maps_to_status_and_code():
+    with (
+        patch("server.settings") as mock_settings,
+        patch("server.engine.process_input", new=AsyncMock(side_effect=EngineError("engine down"))),
+        patch("server._store_memory_if_enabled"),
+    ):
+        mock_settings.debug = False
+        mock_settings.namo_api_keys = None
+        mock_settings.namo_api_default_plan = "public"
+        mock_settings.public_base_url = None
+        mock_settings.default_engine = "omega"
+        mock_settings.memory_logging = 0
+        response = client.post("/chat", json={"text": "hi", "session_id": "err-engine"})
+    assert response.status_code == 502
+    data = response.json()
+    assert data["error_code"] == "ENGINE_ERROR"
+    assert data["success"] is False
+
+
+# --- unexpected errors: no stack trace in production ---
+
+
+def test_unhandled_exception_hides_detail_in_prod():
+    with (
+        patch("server.settings") as mock_settings,
+        patch("server.engine.process_input", new=AsyncMock(side_effect=ValueError("boom"))),
+        patch("server._store_memory_if_enabled"),
+    ):
+        mock_settings.debug = False
+        mock_settings.namo_api_keys = None
+        mock_settings.namo_api_default_plan = "public"
+        mock_settings.public_base_url = None
+        mock_settings.default_engine = "omega"
+        mock_settings.memory_logging = 0
+        response = client_no_raise.post("/chat", json={"text": "hi", "session_id": "err-500"})
+    assert response.status_code == 500
+    data = response.json()
+    assert data["success"] is False
+    assert data["error_code"] == "INTERNAL_ERROR"
+    assert "detail" not in data  # no stack trace leaked in production
+
+
+def test_unhandled_exception_exposes_detail_in_debug():
+    with (
+        patch("server.settings") as mock_settings,
+        patch("server.engine.process_input", new=AsyncMock(side_effect=ValueError("boom"))),
+        patch("server._store_memory_if_enabled"),
+    ):
+        mock_settings.debug = True
+        mock_settings.namo_api_keys = None
+        mock_settings.namo_api_default_plan = "public"
+        mock_settings.public_base_url = None
+        mock_settings.default_engine = "omega"
+        mock_settings.memory_logging = 0
+        response = client_no_raise.post("/chat", json={"text": "hi", "session_id": "err-dbg"})
+    assert response.status_code == 500
+    data = response.json()
+    assert "ValueError" in data["detail"]


### PR DESCRIPTION
## Summary

Phase 1, step 3 per `ROADMAP.md` — consistent, client-safe error handling. **Conservative scope** (confirmed): the API layer only. No persona-engine semantics or `process_input()` contracts are touched, so deployed behaviour is unaffected.

## Changes

- **`core/exceptions.py`** (new)
  - `NamoAPIError` base + `AuthenticationError` (401) / `RateLimitError` (429) / `EngineError` (502) / `MemoryServiceError` (502), each with a stable `error_code`.
  - `error_payload()` — builds `{success, error, error_code[, detail]}`; **omits `detail` entirely when `None`** so production never leaks diagnostic context.
- **`server.py`** + **`memory_service.py`** — global handlers for `NamoAPIError`, `RequestValidationError`, and a catch-all `Exception`. All return the same JSON shape; `detail` is exposed **only when `settings.debug` is True**. Errors are logged through the structured loggers added in step 1.
- **`tests/test_error_handling.py`** (7 tests) — payload helper, exception attributes, validation-error shape, `NamoAPIError` → status/code mapping, and no-stack-trace-in-prod vs detail-in-debug for unhandled errors.

Success-path contracts (`/chat`, `/v1/chat`, `process_input()`) are unchanged; `HTTPException`-based routes (e.g. admin `_assert_admin`) keep FastAPI's default handling.

## Testing

All five gates green locally:
- `pytest` — **351 passed** (344 + 7)
- `ruff` / `black` — pass
- `pip-audit` — no known vulnerabilities
- `bandit -r .` — 0 issues

## Phase 1 status: ~95%
Remaining: **step 4** — top up unit-test coverage on any thinner paths. Per the ROADMAP workflow I'll pause for confirmation before starting step 4 (after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a)_