### PR TITLE
Phase 2 (step 1): 18+ age gate for the web client

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,15 +49,15 @@ NaMo Forbidden Archive เป็นระบบ AI Persona สำหรับบ
 ---
 
 ### **Phase 2: ปรับปรุงประสบการณ์ผู้ใช้ (UX/UI)** (1-2 สัปดาห์)
-- [ ] ปรับ Web UI ให้สวยงาม ทันสมัย และ Responsive
-- [ ] เพิ่มฟีเจอร์ History, Settings, Persona Switch
+- [~] ปรับ Web UI ให้สวยงาม ทันสมัย และ Responsive — ดีไซน์ ivory/crimson มีอยู่แล้ว + responsive breakpoints (ปรับเพิ่มได้)
+- [~] เพิ่มฟีเจอร์ History, Settings, Persona Switch — Settings + local history มีแล้ว; เหลือ Persona Switch UI
 - [ ] เพิ่ม Voice Input/Output (Whisper + ElevenLabs)
 - [ ] สร้าง Landing Page สำหรับขาย
-- [ ] เพิ่ม Age Gate / Content Warning
+- [x] เพิ่ม Age Gate / Content Warning — overlay 18+ (`web/`), ยืนยันแล้วจำผ่าน localStorage; verify ด้วย headless Chromium
 
 **Deliverable:** เว็บแอพที่ใช้งานง่ายและดูเป็นผลิตภัณฑ์
 
-**สถานะ:** ⬜ ยังไม่ทำ
+**สถานะ:** 🟡 กำลังทำ — ก้าว 1 (Age Gate) เสร็จ; เหลือ Persona Switch UI, Voice I/O, Landing Page, ขัดเกลา responsive
 
 ---
 

--- a/web/app.js
+++ b/web/app.js
@@ -566,40 +566,66 @@ function bindEvents() {
 // ---------------------------------------------------------------------------
 // Age gate (18+) — mandatory front-door confirmation
 // ---------------------------------------------------------------------------
+// Returns true when the app may boot now (gate absent or already confirmed).
+// Returns false while the gate is blocking; boot() is deferred until confirm.
 function enforceAgeGate() {
   const gate = document.getElementById("age-gate");
   if (!gate) {
-    return;
+    return true;
   }
   if (localStorage.getItem(STORAGE_KEYS.ageConfirmed) === "1") {
     gate.classList.add("hidden");
-    return;
+    return true;
   }
+
+  // Block the background app: no NSFW history render, no network, no focus escape.
+  const appEl = document.querySelector(".app");
+  if (appEl) {
+    appEl.setAttribute("inert", "");
+  }
+
   const confirmBtn = document.getElementById("age-confirm");
   const leaveBtn = document.getElementById("age-leave");
-  confirmBtn.addEventListener("click", () => {
-    localStorage.setItem(STORAGE_KEYS.ageConfirmed, "1");
-    gate.classList.add("hidden");
-  });
-  leaveBtn.addEventListener("click", () => {
-    // Do not enter the app; replace the gate with a farewell that stays blocking.
-    gate.innerHTML =
-      '<div class="agegate__card"><div class="agegate__sigil"></div>' +
-      "<h2>ขอบคุณที่แวะมา</h2><p>เนื้อหานี้สำหรับผู้ที่มีอายุ 18 ปีขึ้นไปเท่านั้น</p></div>";
-  });
+  if (confirmBtn) {
+    confirmBtn.focus();
+    confirmBtn.addEventListener("click", () => {
+      localStorage.setItem(STORAGE_KEYS.ageConfirmed, "1");
+      gate.classList.add("hidden");
+      if (appEl) {
+        appEl.removeAttribute("inert");
+      }
+      boot();
+    });
+  }
+  if (leaveBtn) {
+    leaveBtn.addEventListener("click", () => {
+      // Do not enter the app; replace the gate with a farewell that stays blocking.
+      gate.innerHTML =
+        '<div class="agegate__card"><div class="agegate__sigil"></div>' +
+        "<h2>ขอบคุณที่แวะมา</h2><p>เนื้อหานี้สำหรับผู้ที่มีอายุ 18 ปีขึ้นไปเท่านั้น</p></div>";
+    });
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
 // Boot
 // ---------------------------------------------------------------------------
-function init() {
-  enforceAgeGate();
+// Full application boot — runs exactly once, only after the age gate is passed.
+function boot() {
   loadState();
   updateSessionUI();
   updateStreamToggleUI();
   renderMessages();
   bindEvents();
   pingServer();
+}
+
+function init() {
+  if (!enforceAgeGate()) {
+    return; // gate is blocking; boot() will run when the user confirms 18+
+  }
+  boot();
 }
 
 init();

--- a/web/app.js
+++ b/web/app.js
@@ -11,6 +11,7 @@ const STORAGE_KEYS = {
   sessionId: "namo_session_id",
   messages: "namo_messages",
   streamMode: "namo_stream_mode",
+  ageConfirmed: "namo_age_confirmed",
 };
 
 const state = {
@@ -563,9 +564,36 @@ function bindEvents() {
 }
 
 // ---------------------------------------------------------------------------
+// Age gate (18+) — mandatory front-door confirmation
+// ---------------------------------------------------------------------------
+function enforceAgeGate() {
+  const gate = document.getElementById("age-gate");
+  if (!gate) {
+    return;
+  }
+  if (localStorage.getItem(STORAGE_KEYS.ageConfirmed) === "1") {
+    gate.classList.add("hidden");
+    return;
+  }
+  const confirmBtn = document.getElementById("age-confirm");
+  const leaveBtn = document.getElementById("age-leave");
+  confirmBtn.addEventListener("click", () => {
+    localStorage.setItem(STORAGE_KEYS.ageConfirmed, "1");
+    gate.classList.add("hidden");
+  });
+  leaveBtn.addEventListener("click", () => {
+    // Do not enter the app; replace the gate with a farewell that stays blocking.
+    gate.innerHTML =
+      '<div class="agegate__card"><div class="agegate__sigil"></div>' +
+      "<h2>ขอบคุณที่แวะมา</h2><p>เนื้อหานี้สำหรับผู้ที่มีอายุ 18 ปีขึ้นไปเท่านั้น</p></div>";
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Boot
 // ---------------------------------------------------------------------------
 function init() {
+  enforceAgeGate();
   loadState();
   updateSessionUI();
   updateStreamToggleUI();

--- a/web/index.html
+++ b/web/index.html
@@ -172,6 +172,25 @@
       </div>
     </div>
 
+    <div class="agegate" id="age-gate" role="dialog" aria-modal="true" aria-labelledby="age-gate-title">
+      <div class="agegate__card">
+        <div class="agegate__sigil"></div>
+        <h2 id="age-gate-title">Adults Only · 18+</h2>
+        <p>
+          NaMo Forbidden Archive มีเนื้อหาทางเพศและบทสนทนาสำหรับผู้ใหญ่โดยเจตนา
+          หากคุณอายุต่ำกว่า 18 ปี หรืออยู่ในเขตที่เนื้อหาลักษณะนี้ผิดกฎหมาย โปรดออกจากหน้านี้
+        </p>
+        <p class="agegate__warn">
+          การกดเข้าสู่ระบบถือว่าคุณยืนยันว่ามีอายุ 18 ปีบริบูรณ์ขึ้นไป
+          และยินยอมรับชมเนื้อหาสำหรับผู้ใหญ่
+        </p>
+        <div class="agegate__actions">
+          <button class="btn btn--ghost" id="age-leave" type="button">ออก (อายุต่ำกว่า 18)</button>
+          <button class="btn btn--primary" id="age-confirm" type="button">ฉันอายุ 18+ · เข้าสู่ระบบ</button>
+        </div>
+      </div>
+    </div>
+
     <script src="app.js"></script>
   </body>
 </html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -705,3 +705,73 @@ body {
     transition: none !important;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Age gate (18+) — mandatory front-door confirmation, not a content filter
+   --------------------------------------------------------------------------- */
+.agegate {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(29, 26, 31, 0.82);
+  backdrop-filter: blur(6px);
+}
+
+.agegate.hidden {
+  display: none;
+}
+
+.agegate__card {
+  width: min(460px, 92vw);
+  padding: 32px;
+  text-align: center;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  animation: rise 0.4s ease-out;
+}
+
+.agegate__sigil {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, var(--accent-bright), var(--accent));
+  box-shadow: 0 0 0 6px rgba(177, 23, 45, 0.12);
+}
+
+.agegate__card h2 {
+  margin: 0 0 12px;
+  font-family: var(--font-display);
+  color: var(--bg-ink);
+}
+
+.agegate__card p {
+  color: var(--olive);
+  margin: 0 0 14px;
+  line-height: 1.55;
+}
+
+.agegate__warn {
+  font-size: 0.9rem;
+  color: var(--accent);
+}
+
+.agegate__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+@media (min-width: 480px) {
+  .agegate__actions {
+    flex-direction: row-reverse;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary

First step of **Phase 2 (UX/UI)** per `ROADMAP.md` — the "Age Gate / Content Warning" item. A mandatory 18+ front-door confirmation for this NSFW product. This is a **legal/compliance gate, not a content filter** — no persona/content behaviour is touched (consistent with CLAUDE.md's NSFW policy).

I started here because it's the most objective, self-contained, and commercially-critical Phase 2 item (the rest — visual polish, landing page — involve design taste I'd rather align with you on).

## Changes (web/, vanilla JS/CSS, no build step)

- **`index.html`** — age-gate overlay: Thai 18+ warning + "เข้าสู่ระบบ (18+)" / "ออก" actions.
- **`styles.css`** — `.agegate` styling matching the existing ivory/crimson theme tokens; actions stack on mobile, row on ≥480px.
- **`app.js`** — `enforceAgeGate()` runs before boot: if `namo_age_confirmed` is already set it hides immediately; otherwise confirming persists the flag in `localStorage` (returning users skip it), and leaving replaces the gate with a blocking farewell.

## Testing

Driven end-to-end with the pre-installed headless Chromium:
1. Gate visible on first load ✓
2. Hidden after confirming 18+ ✓
3. `localStorage.namo_age_confirmed = "1"` persisted ✓
4. Stays hidden after reload ✓

Frontend-only change — no Python touched, so the `build-test` gates (ruff/black/pytest/pip-audit/bandit) are unaffected.

## Phase 2 remaining (proposed next steps)
- Persona Switch UI (engine already supports the `engine` field — just needs a selector)
- Voice I/O (Whisper + ElevenLabs) — larger, needs backend work
- Landing page + visual polish (design-taste — will check direction with you)

Per the ROADMAP workflow I'll pause for confirmation on the next Phase 2 step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a)_