### PR TITLE
Phase 2 (step 2): persona switch UI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,14 +50,14 @@ NaMo Forbidden Archive เป็นระบบ AI Persona สำหรับบ
 
 ### **Phase 2: ปรับปรุงประสบการณ์ผู้ใช้ (UX/UI)** (1-2 สัปดาห์)
 - [~] ปรับ Web UI ให้สวยงาม ทันสมัย และ Responsive — ดีไซน์ ivory/crimson มีอยู่แล้ว + responsive breakpoints (ปรับเพิ่มได้)
-- [~] เพิ่มฟีเจอร์ History, Settings, Persona Switch — Settings + local history มีแล้ว; เหลือ Persona Switch UI
+- [x] เพิ่มฟีเจอร์ History, Settings, Persona Switch — Settings + local history มีแล้ว; เพิ่ม Persona Switch (topbar selector, ส่ง `engine`, จำผ่าน localStorage)
 - [ ] เพิ่ม Voice Input/Output (Whisper + ElevenLabs)
 - [ ] สร้าง Landing Page สำหรับขาย
 - [x] เพิ่ม Age Gate / Content Warning — overlay 18+ (`web/`), ยืนยันแล้วจำผ่าน localStorage; verify ด้วย headless Chromium
 
 **Deliverable:** เว็บแอพที่ใช้งานง่ายและดูเป็นผลิตภัณฑ์
 
-**สถานะ:** 🟡 กำลังทำ — ก้าว 1 (Age Gate) เสร็จ; เหลือ Persona Switch UI, Voice I/O, Landing Page, ขัดเกลา responsive
+**สถานะ:** 🟡 กำลังทำ — ก้าว 1 (Age Gate) + ก้าว 2 (Persona Switch UI) เสร็จ; เหลือ Voice I/O, Landing Page, ขัดเกลา responsive
 
 ---
 

--- a/web/app.js
+++ b/web/app.js
@@ -12,7 +12,10 @@ const STORAGE_KEYS = {
   messages: "namo_messages",
   streamMode: "namo_stream_mode",
   ageConfirmed: "namo_age_confirmed",
+  engine: "namo_engine",
 };
+
+const DEFAULT_ENGINE = "omega";
 
 const state = {
   baseUrl: "",
@@ -20,6 +23,7 @@ const state = {
   messages: [],
   loading: false,
   streamMode: true,
+  engine: DEFAULT_ENGINE,
 };
 
 const dom = {
@@ -49,6 +53,7 @@ const dom = {
   statusStageDesc: document.getElementById("status-stage-desc"),
   emotionProse: document.getElementById("emotion-prose"),
   streamToggle: document.getElementById("stream-toggle"),
+  personaSelect: document.getElementById("persona-select"),
   ebarJoy: document.getElementById("ebar-joy"),
   ebarArousal: document.getElementById("ebar-arousal"),
   ebarTrust: document.getElementById("ebar-trust"),
@@ -104,6 +109,9 @@ function loadState() {
 
   const storedStream = localStorage.getItem(STORAGE_KEYS.streamMode);
   state.streamMode = storedStream === null ? true : storedStream === "1";
+
+  const storedEngine = localStorage.getItem(STORAGE_KEYS.engine);
+  state.engine = storedEngine || DEFAULT_ENGINE;
 }
 
 function saveMessages() {
@@ -346,7 +354,7 @@ async function sendMessagePlain(text) {
     const response = await fetch(`${state.baseUrl}/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text, session_id: state.sessionId }),
+      body: JSON.stringify({ text, session_id: state.sessionId, engine: state.engine }),
     });
 
     if (!response.ok) throw new Error(`API error: ${response.status}`);
@@ -396,7 +404,7 @@ async function sendMessageStream(text) {
     const response = await fetch(`${state.baseUrl}/v1/chat/stream`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text, session_id: state.sessionId }),
+      body: JSON.stringify({ text, session_id: state.sessionId, engine: state.engine }),
     });
 
     if (!response.ok) throw new Error(`API error: ${response.status}`);
@@ -549,6 +557,13 @@ function bindEvents() {
     updateStreamToggleUI();
   });
 
+  if (dom.personaSelect) {
+    dom.personaSelect.addEventListener("change", () => {
+      state.engine = dom.personaSelect.value || DEFAULT_ENGINE;
+      localStorage.setItem(STORAGE_KEYS.engine, state.engine);
+    });
+  }
+
   dom.saveSettings.addEventListener("click", () => {
     const value = dom.baseUrlInput.value.trim();
     if (value) {
@@ -616,6 +631,9 @@ function boot() {
   loadState();
   updateSessionUI();
   updateStreamToggleUI();
+  if (dom.personaSelect) {
+    dom.personaSelect.value = state.engine;
+  }
   renderMessages();
   bindEvents();
   pingServer();

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,16 @@
           </div>
         </div>
         <div class="topbar__actions">
+          <label class="persona-picker" title="Switch persona engine">
+            <span class="persona-picker__label">Persona</span>
+            <select id="persona-select" class="persona-picker__select">
+              <option value="omega">NaMo · Omega</option>
+              <option value="rinlada">Rinlada · น้าริน</option>
+              <option value="seraphina">Seraphina</option>
+              <option value="dark">Dark NaMo</option>
+              <option value="ultimate">NaMo · Ultimate</option>
+            </select>
+          </label>
           <button class="btn btn--ghost" id="new-session-btn" type="button" title="Start a new conversation">New Session</button>
           <button class="btn btn--ghost" id="ping-button" type="button">Ping</button>
           <button class="btn btn--ghost" id="settings-button" type="button">Settings</button>

--- a/web/styles.css
+++ b/web/styles.css
@@ -707,6 +707,38 @@ body {
 }
 
 /* ---------------------------------------------------------------------------
+   Persona picker (topbar engine selector)
+   --------------------------------------------------------------------------- */
+.persona-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.persona-picker__label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--olive);
+}
+
+.persona-picker__select {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--bg-ink);
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.persona-picker__select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* ---------------------------------------------------------------------------
    Age gate (18+) — mandatory front-door confirmation, not a content filter
    --------------------------------------------------------------------------- */
 .agegate {


### PR DESCRIPTION
## Summary

Phase 2, step 2 per `ROADMAP.md` — the "Persona Switch" part of the History/Settings/Persona Switch item. The engine registry already accepts an `engine` field on each `/chat` request, but the web client had no way to pick one; it always used the server default. This adds a topbar persona selector.

## Changes (web/, vanilla JS/CSS, no build step)

- **`index.html`** — a `<select id="persona-select">` in the topbar listing the five registered engines: `omega` / `rinlada` / `seraphina` / `dark` / `ultimate`.
- **`app.js`** — `state.engine` (default `omega`) persisted under `namo_engine`; **both** the `/chat` and `/v1/chat/stream` request bodies now include `engine`; the selector is restored on boot and updated on change.
- **`styles.css`** — `.persona-picker` styling matching the ivory/crimson theme.

## Testing

Driven with the pre-installed headless Chromium:
1. Selector present, defaults to `omega` ✓
2. Switching to `seraphina` persists `namo_engine` in `localStorage` ✓
3. The `/chat` request body carries `engine: "seraphina"` ✓
4. Selection survives a reload ✓

Frontend-only — no Python touched, so `build-test` is unaffected.

## Phase 2 remaining
- Voice I/O (Whisper + ElevenLabs) — larger, needs backend work
- Landing page + visual polish (design-taste — will check direction with you)

Per the ROADMAP workflow I'll pause for confirmation on the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a)_