### PR TITLE
Phase 1 (step 4): top up unit-test coverage; Phase 1 complete

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@ NaMo Forbidden Archive เป็นระบบ AI Persona สำหรับบ
 - [x] Refactor โค้ดหลักให้ตรง PEP 8 (black + ruff) — CI เขียวครบ
 - [x] แก้ Bug และเพิ่ม Error Handling ที่เหมาะสม — `core/exceptions.py` + global handlers (server + memory), client-safe JSON, ซ่อน stack trace เมื่อ `debug=False`
 - [x] เพิ่ม Structured Logging — `config.setup_logging()` + entry points `server.py`/`memory_service.py`
-- [~] เพิ่ม/ปรับ Unit Test ให้ครอบคลุมมากขึ้น (ก้าว 4; ปัจจุบัน 351 tests — error paths ครอบคลุมแล้ว)
+- [x] เพิ่ม/ปรับ Unit Test ให้ครอบคลุมมากขึ้น — 354 tests, coverage 91%; `adapters/memory.py` 100%, error/edge paths + unknown-engine ครอบคลุม
 - [x] แยก Configuration สำหรับ Production / Development — `debug`/`log_level` คุม logging + error-detail exposure
 
 **ระบบ**
@@ -44,7 +44,7 @@ NaMo Forbidden Archive เป็นระบบ AI Persona สำหรับบ
 
 **Deliverable:** Docker image ที่เสถียร + API ที่พร้อมใช้งาน
 
-**สถานะ:** 🟡 กำลังทำ (~95%) — ก้าว 1 (Logging), 2 (Docker Compose), 3 (Error Handling) เสร็จ; เหลือ ก้าว 4 (เติม Unit Tests เพิ่มเติม)
+**สถานะ:** ✅ เสร็จ (100%) — ก้าว 1 (Logging), 2 (Docker Compose), 3 (Error Handling), 4 (Unit Tests) ครบทุกก้าว
 
 ---
 

--- a/tests/test_memory_adapter.py
+++ b/tests/test_memory_adapter.py
@@ -112,3 +112,20 @@ def test_remote_failure_does_not_raise(tmp_path):
     ):
         # Should not raise
         adapter.store_interaction("msg", "resp")
+
+
+def test_store_local_write_error_is_silent(local_adapter):
+    """A corrupt local store makes json.load fail — store_interaction must not raise."""
+    adapter, db = local_adapter
+    with open(db, "w", encoding="utf-8") as f:
+        f.write("{ not valid json")
+    # json.load inside store_interaction raises; the adapter swallows it
+    adapter.store_interaction("hi", "there", session_id="s-corrupt")
+
+
+def test_get_last_conversation_corrupt_file_returns_none(local_adapter):
+    """A corrupt store file yields None rather than raising."""
+    adapter, db = local_adapter
+    with open(db, "w", encoding="utf-8") as f:
+        f.write("]]not json[[")
+    assert adapter.get_last_conversation() is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -559,3 +559,22 @@ def test_chat_with_engine_override(mock_settings):
     assert response.status_code == 200
     data = response.json()
     assert data["engine"] == "NaMoUltimateBrain"
+
+
+@patch("server.settings")
+def test_chat_with_unknown_engine_returns_400(mock_settings):
+    """An unknown engine name is rejected by the registry with HTTP 400."""
+    mock_settings.namo_api_keys = None
+    mock_settings.namo_api_default_plan = "public"
+    mock_settings.public_base_url = None
+    mock_settings.default_engine = "omega"
+    mock_settings.memory_logging = 0
+
+    with patch("server._store_memory_if_enabled"):
+        response = client.post(
+            "/chat",
+            json={"text": "hi", "engine": "does-not-exist", "session_id": "unknown-eng"},
+        )
+
+    assert response.status_code == 400
+    assert "unknown_engine" in response.json()["detail"]


### PR DESCRIPTION
Fill in the remaining thin paths flagged by coverage, without touching engine internals (conservative scope preserved).

- tests/test_memory_adapter.py: cover the local-write error path and the corrupt-file branch of get_last_conversation — adapters/memory.py now 100% (CLAUDE.md requires both service-available and absent/error paths per adapter)
- tests/test_server.py: cover the unknown-engine -> HTTP 400 registry path
- 354 tests pass; overall coverage 91%

Mark Phase 1 complete in ROADMAP.md (all four steps done).


Claude-Session: https://claude.ai/code/session_01DF3K88PiuXU4RdFXX2Zo1a